### PR TITLE
Update to version for CORS and retraining on Lite plan

### DIFF
--- a/getting-started.md
+++ b/getting-started.md
@@ -2,7 +2,7 @@
 
 copyright:
   years: 2015, 2018
-lastupdated: "2018-04-02"
+lastupdated: "2018-04-12"
 
 ---
 
@@ -57,7 +57,7 @@ If you use {{site.data.keyword.Bluemix_dedicated_notm}}, create your service ins
 
     ```bash
     curl -X POST --form "images_file=@fruitbowl.jpg" \
-    "https://gateway-a.watsonplatform.net/visual-recognition/api/v3/classify?api_key={api-key}&version=2016-05-20"
+    "https://gateway-a.watsonplatform.net/visual-recognition/api/v3/classify?api_key={api-key}&version=2018-03-19"
     ```
     {: pre}
 
@@ -136,7 +136,7 @@ If you use {{site.data.keyword.Bluemix_dedicated_notm}}, create your service ins
 
     ```bash
     curl -X POST --form "images_file=@Ginni_Rometty.jpg" \
-    "https://gateway-a.watsonplatform.net/visual-recognition/api/v3/detect_faces?api_key={api-key}&version=2016-05-20"
+    "https://gateway-a.watsonplatform.net/visual-recognition/api/v3/detect_faces?api_key={api-key}&version=2018-03-19"
     ```
     {: pre}
 

--- a/release-notes.md
+++ b/release-notes.md
@@ -2,7 +2,7 @@
 
 copyright:
   years: 2015, 2018
-lastupdated: "2018-04-05"
+lastupdated: "2018-04-11"
 
 ---
 
@@ -34,7 +34,7 @@ API requests require a version parameter that takes a date in the format `versio
 
 Send the version parameter with every API request. The service uses the API version for the date you specify, or the most recent version before that date. Don't default to the current date. Instead, specify a date that matches a version that is compatible with your app, and don't change it until your app is ready for a later version.
 
-The current version is `2016-05-20`.
+The current version is `2018-03-19`.
 
 ## Beta features
 {: #beta}
@@ -45,6 +45,21 @@ The current version is `2016-05-20`.
 {: #changelog}
 
 The following new features and changes to the service are available.
+
+### 12 April 2018
+{: #12april2018}
+
+- **Support for retraining a custom model on the Lite plan**
+
+    Under the Lite plan, you no longer have to delete and create another custom model when you want to update or retrain the model. You can now update a custom model as long as you remain under daily and monthly [limits](https://console.bluemix.net/catalog/services/visual-recognition) of the plan.
+
+    If you need to have multiple models or multiple versions of the same model, update from the Lite plan to a billable account.
+
+- **New minor version with support for CORS**
+
+    **Version:** `2018-03-19`
+
+    We now support Cross-Origin Resource Sharing (CORS) headers when you specify `version=2018-03-19` in requests.
 
 ### 5 April 2018
 {: #5april2018}

--- a/tutorial-custom-classifier.md
+++ b/tutorial-custom-classifier.md
@@ -2,7 +2,7 @@
 
 copyright:
   years: 2015, 2018
-lastupdated: "2018-04-02"
+lastupdated: "2018-04-11"
 
 ---
 
@@ -44,7 +44,7 @@ Use the credentials that you copied in "Getting started tutorial." If you didn't
     --form "goldenretriever_positive_examples=@golden-retriever.zip" \
     --form "negative_examples=@cats.zip" \
     --form "name=dogs" \
-    "https://gateway-a.watsonplatform.net/visual-recognition/api/v3/classifiers?api_key={api-key}&version=2016-05-20"
+    "https://gateway-a.watsonplatform.net/visual-recognition/api/v3/classifiers?api_key={api-key}&version=2018-03-19"
     ```
     {: pre}
 
@@ -81,14 +81,11 @@ Use the credentials that you copied in "Getting started tutorial." If you didn't
 
     ```bash
     curl -X GET \
-    "https://gateway-a.watsonplatform.net/visual-recognition/api/v3/classifiers/{classifier_id}?api_key={api-key}&version=2016-05-20"
+    "https://gateway-a.watsonplatform.net/visual-recognition/api/v3/classifiers/{classifier_id}?api_key={api-key}&version=2018-03-19"
     ```
     {: pre}
 
 ## Step 3: Updating an existing custom model
-
-If you have an API key for a Lite plan and want to update a custom model, you must create another service instance on a Standard plan and re-create your custom model. Follow the steps in the [Before you begin](/docs/services/visual-recognition/getting-started.html#prerequisites) section of the "Getting started tutorial" and make sure to select the Standard plan.
-{: tip}
 
 You can update a custom model either by adding classes to the model or by adding images to an existing class. Here, you improve the model that you created in Step 2 by adding a *Dalmatian* class to the types of dogs that can be classified. You also add images of cats to the negative example set for the "dogs" custom model.
 
@@ -102,7 +99,7 @@ You can update a custom model either by adding classes to the model or by adding
     curl -X POST \
     --form "dalmatian_positive_examples=@dalmatian.zip" \
     --form "negative_examples=@more-cats.zip" \
-    "https://gateway-a.watsonplatform.net/visual-recognition/api/v3/classifiers/{classifier_id}?api_key={api-key}&version=2016-05-20"
+    "https://gateway-a.watsonplatform.net/visual-recognition/api/v3/classifiers/{classifier_id}?api_key={api-key}&version=2018-03-19"
     ```
     {: pre}
 
@@ -143,7 +140,7 @@ You can update a custom model either by adding classes to the model or by adding
 
     ```bash
     curl -X GET \
-    "https://gateway-a.watsonplatform.net/visual-recognition/api/v3/classifiers/{classifier_id}?api_key={api-key}&version=2016-05-20"
+    "https://gateway-a.watsonplatform.net/visual-recognition/api/v3/classifiers/{classifier_id}?api_key={api-key}&version=2018-03-19"
     ```
     {: pre}
 
@@ -160,7 +157,7 @@ When the new model is ready, call it to see how it performs.
     curl -X POST \
     --form "images_file=@dogs.jpg" \
     --form "classifier_ids=dogs__1941945966,default" \
-    "https://gateway-a.watsonplatform.net/visual-recognition/api/v3/classify?api_key={api-key}&version=2016-05-20"
+    "https://gateway-a.watsonplatform.net/visual-recognition/api/v3/classify?api_key={api-key}&version=2018-03-19"
     ```
     {: pre}
 
@@ -247,7 +244,7 @@ To delete the model, call the `DELETE /v3/classifiers/{classifier_id}` method. R
 
 ```bash
 curl -X DELETE \
-"https://gateway-a.watsonplatform.net/visual-recognition/api/v3/classifiers/{classifier_id}?api_key={api-key}&version=2016-05-20"
+"https://gateway-a.watsonplatform.net/visual-recognition/api/v3/classifiers/{classifier_id}?api_key={api-key}&version=2018-03-19"
 ```
 {: pre}
 


### PR DESCRIPTION
Full support for CORS headers requires the new minor version
`2018-03-19`