### PR TITLE
Remove link definition section itself

### DIFF
--- a/nl/de/object-detection.md
+++ b/nl/de/object-detection.md
@@ -2,7 +2,7 @@
 
 copyright:
   years: 2015, 2019
-lastupdated: "2019-03-06"
+lastupdated: "2019-04-16"
 
 keywords: custom object detection,object detection,bounding boxes,visual inspection
 subcollection: visual-recognition
@@ -22,10 +22,6 @@ subcollection: visual-recognition
 {:java: .ph data-hd-programlang='java'}
 {:python: .ph data-hd-programlang='python'}
 {:swift: .ph data-hd-programlang='swift'}
-
-<!-- Link definitions -->
-
-[api-ref-v4]: https://{DomainName}/apidocs/visual-recognition-v4
 
 # Benutzerdefinierte Objekterkennung (Beta)
 {: #object-detection-overview}

--- a/nl/de/recognize-text.md
+++ b/nl/de/recognize-text.md
@@ -2,7 +2,7 @@
 
 copyright:
   years: 2015, 2019
-lastupdated: "2019-03-06"
+lastupdated: "2019-04-16"
 
 keywords: Text recognition,Visual Recognition beta Text model,Text model,recognize text
 
@@ -19,10 +19,6 @@ subcollection: visual-recognition
 {:pre: .pre}
 {:codeblock: .codeblock}
 {:screen: .screen}
-
-<!-- Link definitions -->
-
-[api-ref-text]: https://{DomainName}/apidocs/visual-recognition/visual-recognition-v3-text
 
 # Texterkennung in natürlichen Szenen (Beta)
 {: #recognize-text}

--- a/nl/de/release-notes.md
+++ b/nl/de/release-notes.md
@@ -2,7 +2,7 @@
 
 copyright:
   years: 2015, 2019
-lastupdated: "2019-03-06"
+lastupdated: "2019-04-16"
 
 keywords: new features,updates to Visual Recognition,what's new with Visual Recognition
 
@@ -19,11 +19,6 @@ subcollection: visual-recognition
 {:pre: .pre}
 {:codeblock: .codeblock}
 {:screen: .screen}
-
-<!-- Link definitions -->
-
-[watson-studio-reg]: https://dataplatform.ibm.com/registration/stepone?target=watson_vision_combined&context=wdp&apps=watson_studio&cm_sp=WatsonPlatform-WatsonPlatform-_-OnPageNavCTA-IBMWatson_VisualRecognition-_-docs
-[demo]: https://www.ibm.com/watson/services/visual-recognition/demo
 
 # Releaseinformationen
 {: #release-notes}

--- a/nl/es/object-detection.md
+++ b/nl/es/object-detection.md
@@ -2,7 +2,7 @@
 
 copyright:
   years: 2015, 2019
-lastupdated: "2019-03-06"
+lastupdated: "2019-04-16"
 
 keywords: custom object detection,object detection,bounding boxes,visual inspection
 subcollection: visual-recognition
@@ -22,10 +22,6 @@ subcollection: visual-recognition
 {:java: .ph data-hd-programlang='java'}
 {:python: .ph data-hd-programlang='python'}
 {:swift: .ph data-hd-programlang='swift'}
-
-<!-- Link definitions -->
-
-[api-ref-v4]: https://{DomainName}/apidocs/visual-recognition-v4
 
 # Custom Object Detection (Beta)
 {: #object-detection-overview}

--- a/nl/es/recognize-text.md
+++ b/nl/es/recognize-text.md
@@ -2,7 +2,7 @@
 
 copyright:
   years: 2015, 2019
-lastupdated: "2019-03-06"
+lastupdated: "2019-04-16"
 
 keywords: Text recognition,Visual Recognition beta Text model,Text model,recognize text
 
@@ -19,10 +19,6 @@ subcollection: visual-recognition
 {:pre: .pre}
 {:codeblock: .codeblock}
 {:screen: .screen}
-
-<!-- Link definitions -->
-
-[api-ref-text]: https://{DomainName}/apidocs/visual-recognition/visual-recognition-v3-text
 
 # Reconocimiento de texto en escenarios naturales (Beta)
 {: #recognize-text}

--- a/nl/es/release-notes.md
+++ b/nl/es/release-notes.md
@@ -2,7 +2,7 @@
 
 copyright:
   years: 2015, 2019
-lastupdated: "2019-03-06"
+lastupdated: "2019-04-16"
 
 keywords: new features,updates to Visual Recognition,what's new with Visual Recognition
 
@@ -19,11 +19,6 @@ subcollection: visual-recognition
 {:pre: .pre}
 {:codeblock: .codeblock}
 {:screen: .screen}
-
-<!-- Link definitions -->
-
-[watson-studio-reg]: https://dataplatform.ibm.com/registration/stepone?target=watson_vision_combined&context=wdp&apps=watson_studio&cm_sp=WatsonPlatform-WatsonPlatform-_-OnPageNavCTA-IBMWatson_VisualRecognition-_-docs
-[demo]: https://www.ibm.com/watson/services/visual-recognition/demo
 
 # Notas del release
 {: #release-notes}

--- a/nl/fr/object-detection.md
+++ b/nl/fr/object-detection.md
@@ -2,7 +2,7 @@
 
 copyright:
   years: 2015, 2019
-lastupdated: "2019-03-06"
+lastupdated: "2019-04-16"
 
 keywords: custom object detection,object detection,bounding boxes,visual inspection
 subcollection: visual-recognition
@@ -22,10 +22,6 @@ subcollection: visual-recognition
 {:java: .ph data-hd-programlang='java'}
 {:python: .ph data-hd-programlang='python'}
 {:swift: .ph data-hd-programlang='swift'}
-
-<!-- Link definitions -->
-
-[api-ref-v4]: https://{DomainName}/apidocs/visual-recognition-v4
 
 # Custom Object Detection (version bêta)
 {: #object-detection-overview}

--- a/nl/fr/recognize-text.md
+++ b/nl/fr/recognize-text.md
@@ -2,7 +2,7 @@
 
 copyright:
   years: 2015, 2019
-lastupdated: "2019-03-06"
+lastupdated: "2019-04-16"
 
 keywords: Text recognition,Visual Recognition beta Text model,Text model,recognize text
 
@@ -19,10 +19,6 @@ subcollection: visual-recognition
 {:pre: .pre}
 {:codeblock: .codeblock}
 {:screen: .screen}
-
-<!-- Link definitions -->
-
-[api-ref-text]: https://{DomainName}/apidocs/visual-recognition/visual-recognition-v3-text
 
 # Reconnaissance de texte dans des scènes de la vie de tous les jours (version bêta)
 {: #recognize-text}

--- a/nl/fr/release-notes.md
+++ b/nl/fr/release-notes.md
@@ -2,7 +2,7 @@
 
 copyright:
   years: 2015, 2019
-lastupdated: "2019-03-06"
+lastupdated: "2019-04-16"
 
 keywords: new features,updates to Visual Recognition,what's new with Visual Recognition
 
@@ -19,11 +19,6 @@ subcollection: visual-recognition
 {:pre: .pre}
 {:codeblock: .codeblock}
 {:screen: .screen}
-
-<!-- Link definitions -->
-
-[watson-studio-reg]: https://dataplatform.ibm.com/registration/stepone?target=watson_vision_combined&context=wdp&apps=watson_studio&cm_sp=WatsonPlatform-WatsonPlatform-_-OnPageNavCTA-IBMWatson_VisualRecognition-_-docs
-[demo]: https://www.ibm.com/watson/services/visual-recognition/demo
 
 # Notes sur l'édition
 {: #release-notes}

--- a/nl/it/object-detection.md
+++ b/nl/it/object-detection.md
@@ -2,7 +2,7 @@
 
 copyright:
   years: 2015, 2019
-lastupdated: "2019-03-06"
+lastupdated: "2019-04-16"
 
 keywords: custom object detection,object detection,bounding boxes,visual inspection
 subcollection: visual-recognition
@@ -22,10 +22,6 @@ subcollection: visual-recognition
 {:java: .ph data-hd-programlang='java'}
 {:python: .ph data-hd-programlang='python'}
 {:swift: .ph data-hd-programlang='swift'}
-
-<!-- Link definitions -->
-
-[api-ref-v4]: https://{DomainName}/apidocs/visual-recognition-v4
 
 # Custom Object Detection (Beta)
 {: #object-detection-overview}

--- a/nl/it/recognize-text.md
+++ b/nl/it/recognize-text.md
@@ -2,7 +2,7 @@
 
 copyright:
   years: 2015, 2019
-lastupdated: "2019-03-06"
+lastupdated: "2019-04-16"
 
 keywords: Text recognition,Visual Recognition beta Text model,Text model,recognize text
 
@@ -19,10 +19,6 @@ subcollection: visual-recognition
 {:pre: .pre}
 {:codeblock: .codeblock}
 {:screen: .screen}
-
-<!-- Link definitions -->
-
-[api-ref-text]: https://{DomainName}/apidocs/visual-recognition/visual-recognition-v3-text
 
 # Riconoscimento del testo in scene naturali (Beta)
 {: #recognize-text}

--- a/nl/it/release-notes.md
+++ b/nl/it/release-notes.md
@@ -2,7 +2,7 @@
 
 copyright:
   years: 2015, 2019
-lastupdated: "2019-03-06"
+lastupdated: "2019-04-16"
 
 keywords: new features,updates to Visual Recognition,what's new with Visual Recognition
 
@@ -19,11 +19,6 @@ subcollection: visual-recognition
 {:pre: .pre}
 {:codeblock: .codeblock}
 {:screen: .screen}
-
-<!-- Link definitions -->
-
-[watson-studio-reg]: https://dataplatform.ibm.com/registration/stepone?target=watson_vision_combined&context=wdp&apps=watson_studio&cm_sp=WatsonPlatform-WatsonPlatform-_-OnPageNavCTA-IBMWatson_VisualRecognition-_-docs
-[demo]: https://www.ibm.com/watson/services/visual-recognition/demo
 
 # Note sulla release
 {: #release-notes}

--- a/nl/ja/object-detection.md
+++ b/nl/ja/object-detection.md
@@ -2,7 +2,7 @@
 
 copyright:
   years: 2015, 2019
-lastupdated: "2019-03-06"
+lastupdated: "2019-04-16"
 
 keywords: custom object detection,object detection,bounding boxes,visual inspection
 subcollection: visual-recognition
@@ -22,10 +22,6 @@ subcollection: visual-recognition
 {:java: .ph data-hd-programlang='java'}
 {:python: .ph data-hd-programlang='python'}
 {:swift: .ph data-hd-programlang='swift'}
-
-<!-- Link definitions -->
-
-[api-ref-v4]: https://{DomainName}/apidocs/visual-recognition-v4
 
 # カスタム物体検出 (ベータ)
 {: #object-detection-overview}

--- a/nl/ja/recognize-text.md
+++ b/nl/ja/recognize-text.md
@@ -2,7 +2,7 @@
 
 copyright:
   years: 2015, 2019
-lastupdated: "2019-03-06"
+lastupdated: "2019-04-16"
 
 keywords: Text recognition,Visual Recognition beta Text model,Text model,recognize text
 
@@ -19,10 +19,6 @@ subcollection: visual-recognition
 {:pre: .pre}
 {:codeblock: .codeblock}
 {:screen: .screen}
-
-<!-- Link definitions -->
-
-[api-ref-text]: https://{DomainName}/apidocs/visual-recognition/visual-recognition-v3-text
 
 # 自然の情景の中のテキストの認識 (ベータ)
 {: #recognize-text}

--- a/nl/ja/release-notes.md
+++ b/nl/ja/release-notes.md
@@ -2,7 +2,7 @@
 
 copyright:
   years: 2015, 2019
-lastupdated: "2019-03-06"
+lastupdated: "2019-04-16"
 
 keywords: new features,updates to Visual Recognition,what's new with Visual Recognition
 
@@ -19,11 +19,6 @@ subcollection: visual-recognition
 {:pre: .pre}
 {:codeblock: .codeblock}
 {:screen: .screen}
-
-<!-- Link definitions -->
-
-[watson-studio-reg]: https://dataplatform.ibm.com/registration/stepone?target=watson_vision_combined&context=wdp&apps=watson_studio&cm_sp=WatsonPlatform-WatsonPlatform-_-OnPageNavCTA-IBMWatson_VisualRecognition-_-docs
-[demo]: https://www.ibm.com/watson/services/visual-recognition/demo
 
 # リリース情報
 {: #release-notes}

--- a/nl/ko/object-detection.md
+++ b/nl/ko/object-detection.md
@@ -2,7 +2,7 @@
 
 copyright:
   years: 2015, 2019
-lastupdated: "2019-03-06"
+lastupdated: "2019-04-16"
 
 keywords: custom object detection,object detection,bounding boxes,visual inspection
 subcollection: visual-recognition
@@ -22,10 +22,6 @@ subcollection: visual-recognition
 {:java: .ph data-hd-programlang='java'}
 {:python: .ph data-hd-programlang='python'}
 {:swift: .ph data-hd-programlang='swift'}
-
-<!-- Link definitions -->
-
-[api-ref-v4]: https://{DomainName}/apidocs/visual-recognition-v4
 
 # 사용자 정의 오브젝트 감지(베타)
 {: #object-detection-overview}

--- a/nl/ko/recognize-text.md
+++ b/nl/ko/recognize-text.md
@@ -2,7 +2,7 @@
 
 copyright:
   years: 2015, 2019
-lastupdated: "2019-03-06"
+lastupdated: "2019-04-16"
 
 keywords: Text recognition,Visual Recognition beta Text model,Text model,recognize text
 
@@ -19,10 +19,6 @@ subcollection: visual-recognition
 {:pre: .pre}
 {:codeblock: .codeblock}
 {:screen: .screen}
-
-<!-- Link definitions -->
-
-[api-ref-text]: https://{DomainName}/apidocs/visual-recognition/visual-recognition-v3-text
 
 # 자연스러운 장면에서 텍스트 인식(베타)
 {: #recognize-text}

--- a/nl/ko/release-notes.md
+++ b/nl/ko/release-notes.md
@@ -2,7 +2,7 @@
 
 copyright:
   years: 2015, 2019
-lastupdated: "2019-03-06"
+lastupdated: "2019-04-16"
 
 keywords: new features,updates to Visual Recognition,what's new with Visual Recognition
 
@@ -19,11 +19,6 @@ subcollection: visual-recognition
 {:pre: .pre}
 {:codeblock: .codeblock}
 {:screen: .screen}
-
-<!-- Link definitions -->
-
-[watson-studio-reg]: https://dataplatform.ibm.com/registration/stepone?target=watson_vision_combined&context=wdp&apps=watson_studio&cm_sp=WatsonPlatform-WatsonPlatform-_-OnPageNavCTA-IBMWatson_VisualRecognition-_-docs
-[demo]: https://www.ibm.com/watson/services/visual-recognition/demo
 
 # 릴리스 정보
 {: #release-notes}

--- a/nl/pt/BR/object-detection.md
+++ b/nl/pt/BR/object-detection.md
@@ -2,7 +2,7 @@
 
 copyright:
   years: 2015, 2019
-lastupdated: "2019-03-06"
+lastupdated: "2019-04-16"
 
 keywords: custom object detection,object detection,bounding boxes,visual inspection
 subcollection: visual-recognition
@@ -22,10 +22,6 @@ subcollection: visual-recognition
 {:java: .ph data-hd-programlang='java'}
 {:python: .ph data-hd-programlang='python'}
 {:swift: .ph data-hd-programlang='swift'}
-
-<!-- Link definitions -->
-
-[api-ref-v4]: https://{DomainName}/apidocs/visual-recognition-v4
 
 # Custom Object Detection (Beta)
 {: #object-detection-overview}

--- a/nl/pt/BR/recognize-text.md
+++ b/nl/pt/BR/recognize-text.md
@@ -2,7 +2,7 @@
 
 copyright:
   years: 2015, 2019
-lastupdated: "2019-03-06"
+lastupdated: "2019-04-16"
 
 keywords: Text recognition,Visual Recognition beta Text model,Text model,recognize text
 
@@ -19,10 +19,6 @@ subcollection: visual-recognition
 {:pre: .pre}
 {:codeblock: .codeblock}
 {:screen: .screen}
-
-<!-- Link definitions -->
-
-[api-ref-text]: https://{DomainName}/apidocs/visual-recognition/visual-recognition-v3-text
 
 # Reconhecimento de texto em cenas naturais (Beta)
 {: #recognize-text}

--- a/nl/pt/BR/release-notes.md
+++ b/nl/pt/BR/release-notes.md
@@ -2,7 +2,7 @@
 
 copyright:
   years: 2015, 2019
-lastupdated: "2019-03-06"
+lastupdated: "2019-04-16"
 
 keywords: new features,updates to Visual Recognition,what's new with Visual Recognition
 
@@ -19,11 +19,6 @@ subcollection: visual-recognition
 {:pre: .pre}
 {:codeblock: .codeblock}
 {:screen: .screen}
-
-<!-- Link definitions -->
-
-[watson-studio-reg]: https://dataplatform.ibm.com/registration/stepone?target=watson_vision_combined&context=wdp&apps=watson_studio&cm_sp=WatsonPlatform-WatsonPlatform-_-OnPageNavCTA-IBMWatson_VisualRecognition-_-docs
-[demo]: https://www.ibm.com/watson/services/visual-recognition/demo
 
 # Nota sobre a Liberação
 {: #release-notes}

--- a/nl/zh/CN/object-detection.md
+++ b/nl/zh/CN/object-detection.md
@@ -2,7 +2,7 @@
 
 copyright:
   years: 2015, 2019
-lastupdated: "2019-03-06"
+lastupdated: "2019-04-16"
 
 keywords: custom object detection,object detection,bounding boxes,visual inspection
 subcollection: visual-recognition
@@ -22,10 +22,6 @@ subcollection: visual-recognition
 {:java: .ph data-hd-programlang='java'}
 {:python: .ph data-hd-programlang='python'}
 {:swift: .ph data-hd-programlang='swift'}
-
-<!-- Link definitions -->
-
-[api-ref-v4]: https://{DomainName}/apidocs/visual-recognition-v4
 
 # 定制对象检测 (Beta)
 {: #object-detection-overview}

--- a/nl/zh/CN/recognize-text.md
+++ b/nl/zh/CN/recognize-text.md
@@ -2,7 +2,7 @@
 
 copyright:
   years: 2015, 2019
-lastupdated: "2019-03-06"
+lastupdated: "2019-04-16"
 
 keywords: Text recognition,Visual Recognition beta Text model,Text model,recognize text
 
@@ -19,10 +19,6 @@ subcollection: visual-recognition
 {:pre: .pre}
 {:codeblock: .codeblock}
 {:screen: .screen}
-
-<!-- Link definitions -->
-
-[api-ref-text]: https://{DomainName}/apidocs/visual-recognition/visual-recognition-v3-text
 
 # 自然场景中的文本识别 (Beta)
 {: #recognize-text}

--- a/nl/zh/CN/release-notes.md
+++ b/nl/zh/CN/release-notes.md
@@ -2,7 +2,7 @@
 
 copyright:
   years: 2015, 2019
-lastupdated: "2019-03-06"
+lastupdated: "2019-04-16"
 
 keywords: new features,updates to Visual Recognition,what's new with Visual Recognition
 
@@ -19,11 +19,6 @@ subcollection: visual-recognition
 {:pre: .pre}
 {:codeblock: .codeblock}
 {:screen: .screen}
-
-<!-- Link definitions -->
-
-[watson-studio-reg]: https://dataplatform.ibm.com/registration/stepone?target=watson_vision_combined&context=wdp&apps=watson_studio&cm_sp=WatsonPlatform-WatsonPlatform-_-OnPageNavCTA-IBMWatson_VisualRecognition-_-docs
-[demo]: https://www.ibm.com/watson/services/visual-recognition/demo
 
 # 发行说明
 {: #release-notes}

--- a/nl/zh/TW/object-detection.md
+++ b/nl/zh/TW/object-detection.md
@@ -2,7 +2,7 @@
 
 copyright:
   years: 2015, 2019
-lastupdated: "2019-03-06"
+lastupdated: "2019-04-16"
 
 keywords: custom object detection,object detection,bounding boxes,visual inspection
 subcollection: visual-recognition
@@ -22,10 +22,6 @@ subcollection: visual-recognition
 {:java: .ph data-hd-programlang='java'}
 {:python: .ph data-hd-programlang='python'}
 {:swift: .ph data-hd-programlang='swift'}
-
-<!-- Link definitions -->
-
-[api-ref-v4]: https://{DomainName}/apidocs/visual-recognition-v4
 
 # 自訂物件偵測（測試版）
 {: #object-detection-overview}

--- a/nl/zh/TW/recognize-text.md
+++ b/nl/zh/TW/recognize-text.md
@@ -2,7 +2,7 @@
 
 copyright:
   years: 2015, 2019
-lastupdated: "2019-03-06"
+lastupdated: "2019-04-16"
 
 keywords: Text recognition,Visual Recognition beta Text model,Text model,recognize text
 
@@ -19,10 +19,6 @@ subcollection: visual-recognition
 {:pre: .pre}
 {:codeblock: .codeblock}
 {:screen: .screen}
-
-<!-- Link definitions -->
-
-[api-ref-text]: https://{DomainName}/apidocs/visual-recognition/visual-recognition-v3-text
 
 # 自然場景中的文字識別（測試版）
 {: #recognize-text}

--- a/nl/zh/TW/release-notes.md
+++ b/nl/zh/TW/release-notes.md
@@ -2,7 +2,7 @@
 
 copyright:
   years: 2015, 2019
-lastupdated: "2019-03-06"
+lastupdated: "2019-04-16"
 
 keywords: new features,updates to Visual Recognition,what's new with Visual Recognition
 
@@ -19,11 +19,6 @@ subcollection: visual-recognition
 {:pre: .pre}
 {:codeblock: .codeblock}
 {:screen: .screen}
-
-<!-- Link definitions -->
-
-[watson-studio-reg]: https://dataplatform.ibm.com/registration/stepone?target=watson_vision_combined&context=wdp&apps=watson_studio&cm_sp=WatsonPlatform-WatsonPlatform-_-OnPageNavCTA-IBMWatson_VisualRecognition-_-docs
-[demo]: https://www.ibm.com/watson/services/visual-recognition/demo
 
 # 版本注意事項
 {: #release-notes}

--- a/object-detection.md
+++ b/object-detection.md
@@ -2,7 +2,7 @@
 
 copyright:
   years: 2015, 2019
-lastupdated: "2019-03-21"
+lastupdated: "2019-04-16"
 
 keywords: custom object detection,object detection,bounding boxes,visual inspection
 subcollection: visual-recognition
@@ -22,10 +22,6 @@ subcollection: visual-recognition
 {:java: .ph data-hd-programlang='java'}
 {:python: .ph data-hd-programlang='python'}
 {:swift: .ph data-hd-programlang='swift'}
-
-<!-- Link definitions -->
-
-[api-ref-v4]: https://{DomainName}/apidocs/visual-recognition-v4
 
 # Custom Object Detection (Beta)
 {: #object-detection-overview}

--- a/recognize-text.md
+++ b/recognize-text.md
@@ -2,7 +2,7 @@
 
 copyright:
   years: 2015, 2019
-lastupdated: "2019-03-06"
+lastupdated: "2019-04-16"
 
 keywords: Text recognition,Visual Recognition beta Text model,Text model,recognize text
 
@@ -19,10 +19,6 @@ subcollection: visual-recognition
 {:pre: .pre}
 {:codeblock: .codeblock}
 {:screen: .screen}
-
-<!-- Link definitions -->
-
-[api-ref-text]: https://{DomainName}/apidocs/visual-recognition/visual-recognition-v3-text
 
 # Text recognition in natural scenes (Beta)
 {: #recognize-text}

--- a/release-notes.md
+++ b/release-notes.md
@@ -2,7 +2,7 @@
 
 copyright:
   years: 2015, 2019
-lastupdated: "2019-03-21"
+lastupdated: "2019-04-16"
 
 keywords: new features,updates to Visual Recognition,what's new with Visual Recognition
 
@@ -19,11 +19,6 @@ subcollection: visual-recognition
 {:pre: .pre}
 {:codeblock: .codeblock}
 {:screen: .screen}
-
-<!-- Link definitions -->
-
-[watson-studio-reg]: https://dataplatform.ibm.com/registration/stepone?target=watson_vision_combined&context=wdp&apps=watson_studio&cm_sp=WatsonPlatform-WatsonPlatform-_-OnPageNavCTA-IBMWatson_VisualRecognition-_-docs
-[demo]: https://www.ibm.com/watson/services/visual-recognition/demo
 
 # Release notes
 {: #release-notes}


### PR DESCRIPTION
Existence of the definition section seems to still cause issues with translated content in navigation.